### PR TITLE
Remove unnecessary cookbook version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 jira cookbook changelog
 -----------------------
 
+vX.Y.Z
+------
+- removed unnecessary cookbook version constraints
+
 v1.0.4
 ------
 - reverting OpenSSL module namespace change

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,8 +9,8 @@ version '1.0.4'
 depends 'database'
 depends 'iptables'
 depends 'java'
-depends 'openssl', '~> 4.0.0'
-depends 'postgresql', '~> 3.4.20'
+depends 'openssl'
+depends 'postgresql'
 
 %w(redhat centos scientific oracle amazon debian ubuntu).each do |os|
   supports os


### PR DESCRIPTION
Addresses #8

As far as I can tell, the openssl cookbook only depends on `#secure_password`,
which is really old, and the postgresql doesn't depend on anything specific to
that version. (There were some recent changes that affect wrapper cookbooks,
but not us here.)